### PR TITLE
Fix kubectl access to kubeconfig in front node (k8s >= v1.18.0)

### DIFF
--- a/tasks/front.yaml
+++ b/tasks/front.yaml
@@ -69,10 +69,11 @@
   notify: restart kubeapi
   with_items: "{{ kube_apiserver_options }}"
 
-- copy:
-    dest: /etc/profile.d/kube.sh
-    content: "export KUBECONFIG=/etc/kubernetes/admin.conf"
-  
+- name: Set KUBECONFIG environment variable
+  lineinfile:
+    dest: /etc/environment
+    line: "KUBECONFIG=/etc/kubernetes/admin.conf"
+
 - name: force handlers
   meta: flush_handlers
 

--- a/tasks/wn.yaml
+++ b/tasks/wn.yaml
@@ -1,7 +1,8 @@
 ---
 - name: Wait for Kube master
   wait_for:
-    path: /etc/profile.d/kube.sh
+    path: /etc/environment
+    search_regex: "KUBECONFIG=/etc/kubernetes/admin.conf"
   delegate_to: "{{kube_server}}"
 
 - name: Add node to kube cluster


### PR DESCRIPTION
Due to changes in kubectl v1.18.0 (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#kubectl) root user (or default user with `sudo`) doesn't have properly configured the `KUBECONFIG` environment variable for reading the configuration file stored in `/etc/kubernetes/admin.conf`.

This makes not possible to execute `sudo kubectl ...` in the front node and causes failures in ansible roles using that command if that environment variable is not explicitly set.

This PR only change the way of setting the `KUBECONFIG` environment variable. Instead of exporting it in `profile.d`, that only sources the files when the (non-root) user login, it's added to `/etc/environment` in order to load the variable globally.