### PR TITLE
Added version v0.12.2 to the nvidia-device-plugin yaml. Using no tag …

### DIFF
--- a/files/nvidia-device-plugin.yml
+++ b/files/nvidia-device-plugin.yml
@@ -32,7 +32,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.12.2
         name: nvidia-device-plugin-ctr
         args: ["--fail-on-init-error=false"]
         securityContext:


### PR DESCRIPTION
…or latest tag may cause following problems: 1) being unable to identify current installed version (see https://github.com/NVIDIA/k8s-device-plugin/issues/318), 2) prevent reproducibility, 3) getting an unstable environment (due to incompatibilities).