### PR TITLE
Possibility to override docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The variables that can be passed to this role and a brief description about them
 	kube_public_dns_name: ""
 	# Email to be used in the Let's Encrypt issuer
 	kube_cert_user_email: jhondoe@server.com
+	# Override default docker version
+	# (installed when not in kube_docker_compatible_versions)
+	kube_docker_version: ""
 	# Options to add in the docker.json file
 	kube_docker_options: {}
 	# Compatible docker versions

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,9 @@ kube_cert_manager_challenge_dns01_ak: ''
 kube_cert_manager_challenge_dns01_sk: ''
 # Optionally a wildcard dns certificate name can be set
 kube_cert_manager_wildcard_cert_dns_name: ''
+# Override default docker version
+# (installed when not in kube_docker_compatible_versions)
+kube_docker_version: ""
 # Options to add in the docker.json file
 kube_docker_options: {}
 # Compatible docker versions

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,7 +20,7 @@ dependencies:
     ntp_servers: "{{ kube_ntp_servers }}"
     when: kube_ntp_servers != []
   - role: 'grycap.docker'
-    docker_version: '19.03.15'
+    docker_version: "{{ kube_docker_version | default('19.03.15', true) }}"
     docker_compatible_versions: "{{kube_docker_compatible_versions}}"
     docker_config_values: "{{ {'exec-opts': ['native.cgroupdriver=systemd'], 'log-driver': 'json-file', 'log-opts': {'max-size': '100m'}, 'storage-driver': 'devicemapper'} | combine(kube_docker_options) }}"
     docker_nvidia_support: '{{ kube_nvidia_support and kube_type_of_node == "wn" }}'
@@ -31,7 +31,7 @@ dependencies:
     docker_nvidia_driver_version: "{{ kube_nvidia_driver_version }}"
     when: ansible_os_family == "RedHat" and kube_install_method == 'kubeadm'
   - role: 'grycap.docker'
-    docker_version: "5:19.03.11~3-0~{{ansible_distribution | lower}}-{{ansible_distribution_release}}"
+    docker_version: "{{ kube_docker_version | default('5:19.03.11~3-0~' + (ansible_distribution | lower) + '-' + ansible_distribution_release, true) }}"
     docker_compatible_versions: "{{kube_docker_compatible_versions}}"
     docker_config_values: "{{ {'exec-opts': ['native.cgroupdriver=systemd'], 'log-driver': 'json-file', 'log-opts': {'max-size': '100m'}, 'storage-driver': 'overlay2'} | combine(kube_docker_options) }}"
     docker_nvidia_support: '{{ kube_nvidia_support and kube_type_of_node == "wn" }}'


### PR DESCRIPTION
Right now the docker version is always reinstalled to 19.03, when it is too new and the version is not in _kube_docker_compatible_versions_ yet.

This PR is to support use-case with docker at latest version using new parameter _kube_docker_version_.

I'm not sure if I'm doing this properly or if it could be done by more simple way (like to support "latest" in _docker_compatible_versions_ in ansible-role-docker role or something?). Also there was probably some reason for sticking docker to given set of versions...

Thanks!