### PR TITLE
Add support to cri-o Container Runtime

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,12 @@ jobs:
       - name: Remove pre-installed kubectl to avoid errors
         run: sudo apt remove buildah podman docker-ce containerd.io -y
 
+      - name: Show installed packages
+        run: sudo dpkq-query -l
+
+      - name: Stop containerd
+        run: sudo systemctl stop containerd; sudo rm -f /var/run/containerd/containerd.sock
+
       - name: Install Ansible
         run: sudo pip3 install dnspython ansible==2.9.22
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker -y
+        run: sudo apt remove buildah podman docker-ce containerd.io -y
 
       - name: Install Ansible
         run: sudo pip3 install dnspython ansible==2.9.22
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker -y
+        run: sudo apt remove buildah podman docker-ce containerd.io -y
 
       - name: Install Ansible
         run: sudo pip3 install ansible==2.9.22
@@ -94,7 +94,7 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker -y
+        run: sudo apt remove buildah podman docker-ce containerd.io -y
 
       - name: Install Ansible
         run: sudo pip3 install ansible==2.9.22

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,12 +24,6 @@ jobs:
       - name: Remove pre-installed kubectl to avoid errors
         run: sudo apt remove buildah podman docker-ce containerd.io -y
 
-      - name: Show installed packages
-        run: sudo dpkq-query -l
-
-      - name: Stop containerd
-        run: sudo systemctl stop containerd; sudo rm -f /var/run/containerd/containerd.sock
-
       - name: Install Ansible
         run: sudo pip3 install dnspython ansible==2.9.22
 
@@ -101,6 +95,12 @@ jobs:
     
       - name: Remove pre-installed kubectl to avoid errors
         run: sudo apt remove buildah podman docker-ce containerd.io -y
+
+      - name: Stop containerd
+        run: sudo systemctl stop containerd; sudo rm -f /var/run/containerd/containerd.sock
+
+      - name: Show installed packages
+        run: sudo dpkg-query -l
 
       - name: Install Ansible
         run: sudo pip3 install ansible==2.9.22

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker-ce containerd.io -y
+        run: sudo apt remove buildah podman -y
 
       - name: Install Ansible
         run: sudo pip3 install dnspython ansible==2.9.22
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker-ce containerd.io -y
+        run: sudo apt remove buildah podman -y
 
       - name: Install Ansible
         run: sudo pip3 install ansible==2.9.22
@@ -94,13 +94,10 @@ jobs:
         run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
     
       - name: Remove pre-installed kubectl to avoid errors
-        run: sudo apt remove buildah podman docker-ce containerd.io -y
+        run: sudo apt remove buildah podman -y
 
       - name: Stop containerd
         run: sudo systemctl stop containerd; sudo rm -f /var/run/containerd/containerd.sock
-
-      - name: Show installed packages
-        run: sudo dpkg-query -l
 
       - name: Install Ansible
         run: sudo pip3 install ansible==2.9.22

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
         run: sudo printf '[defaults]\nhost_key_checking = False\nroles_path=../' > ansible.cfg
   
       - name: Install geerlingguy.ntp
-        run: sudo ansible-galaxy install geerlingguy.ntp grycap.docker
+        run: sudo ansible-galaxy install geerlingguy.ntp grycap.docker grycap.cri_o
 
       - name: Basic role syntax check
         run: sudo ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,3 +80,39 @@ jobs:
 
       - name: Test nodes
         run: sudo kubectl -s https://localhost:6443 --insecure-skip-tls-verify --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes
+
+
+  test-crio:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Install python
+        run: sudo apt update && sudo apt install -y python3 python3-pip python3-setuptools
+    
+      - name: Remove pre-installed kubectl to avoid errors
+        run: sudo apt remove buildah podman docker -y
+
+      - name: Install Ansible
+        run: sudo pip3 install ansible==2.9.22
+
+      - name: Create ansible.cfg with correct roles_path
+        run: sudo printf '[defaults]\nhost_key_checking = False\nroles_path=../' > ansible.cfg
+
+      - name: Install geerlingguy.ntp
+        run: sudo ansible-galaxy install geerlingguy.ntp grycap.crio
+
+      - name: Basic role syntax check
+        run: sudo ansible-playbook tests/test-crio.yml -i tests/inventory --syntax-check
+
+      - name: Basic role check in front
+        run: sudo ansible-playbook tests/test-crio.yml -i tests/inventory
+
+      - name: Basic role check in wn
+        run: sudo ansible-playbook tests/test-crio.yml -i tests/inventory -e kube_type_of_node=wn -e kube_server=localhost
+
+      - name: Test nodes
+        run: sudo kubectl -s https://localhost:6443 --insecure-skip-tls-verify --kubeconfig /etc/kubernetes/admin.conf  get nodes

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,7 @@ jobs:
         run: sudo printf '[defaults]\nhost_key_checking = False\nroles_path=../' > ansible.cfg
 
       - name: Install geerlingguy.ntp
-        run: sudo ansible-galaxy install geerlingguy.ntp grycap.cri_o
+        run: sudo ansible-galaxy install geerlingguy.ntp grycap.docker grycap.cri_o
 
       - name: Basic role syntax check
         run: sudo ansible-playbook tests/test-crio.yml -i tests/inventory --syntax-check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,7 @@ jobs:
         run: sudo printf '[defaults]\nhost_key_checking = False\nroles_path=../' > ansible.cfg
 
       - name: Install geerlingguy.ntp
-        run: sudo ansible-galaxy install geerlingguy.ntp grycap.crio
+        run: sudo ansible-galaxy install geerlingguy.ntp grycap.cri_o
 
       - name: Basic role syntax check
         run: sudo ansible-playbook tests/test-crio.yml -i tests/inventory --syntax-check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
         run: sudo printf '[defaults]\nhost_key_checking = False\nroles_path=../' > ansible.cfg
   
       - name: Install geerlingguy.ntp
-        run: sudo ansible-galaxy install geerlingguy.ntp grycap.docker
+        run: sudo ansible-galaxy install geerlingguy.ntp grycap.docker grycap.cri_o
 
       - name: Basic role syntax check
         run: sudo ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ kubelet_extra_args: ''
 # Kube API server options
 kube_apiserver_options: []
 # CRI runtime
-kube_cri_runtime: docker # docker or containerd
+kube_cri_runtime: docker # docker, containerd or crio
 # Flag to set HELM to be installed
 kube_install_helm: true
 # Helm version

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,7 @@ dependencies:
     docker_compose_version: ""
     docker_containerd_only: "{{ (kube_cri_runtime == 'containerd') | bool }}"
     docker_nvidia_driver_version: "{{ kube_nvidia_driver_version }}"
-    when: ansible_os_family == "RedHat" and kube_install_method == 'kubeadm'
+    when: ansible_os_family == "RedHat" and kube_install_method == 'kubeadm' and kube_cri_runtime != 'crio'
   - role: 'grycap.docker'
     docker_version: "{{ kube_docker_version | default('5:19.03.11~3-0~' + (ansible_distribution | lower) + '-' + ansible_distribution_release, true) }}"
     docker_compatible_versions: "{{kube_docker_compatible_versions}}"
@@ -40,4 +40,7 @@ dependencies:
     docker_compose_version: ""
     docker_containerd_only: "{{ (kube_cri_runtime == 'containerd') | bool }}"
     docker_nvidia_driver_version: "{{ kube_nvidia_driver_version }}"
-    when: ansible_os_family == "Debian" and kube_install_method == 'kubeadm'
+    when: ansible_os_family == "Debian" and kube_install_method == 'kubeadm' and kube_cri_runtime != 'crio'
+  - role: 'grycap.cri_o'
+    when: ansible_os_family == "Debian" and kube_install_method == 'kubeadm' and kube_cri_runtime == 'crio'
+  

--- a/tasks/kubeadm.yaml
+++ b/tasks/kubeadm.yaml
@@ -40,7 +40,7 @@
     command: sysctl --system
     when: containerd_sysctl is changed
 
-  when: kube_cri_runtime == "containerd"
+  when: kube_cri_runtime in ["containerd", "crio"]
 
 - name: Include "{{ansible_os_family}}" Kubernetes recipe
   include_tasks: "{{ansible_os_family}}.yaml"

--- a/tests/test-crio.yml
+++ b/tests/test-crio.yml
@@ -9,9 +9,6 @@
       kube_deploy_dashboard: true
       kube_install_ingress: true
       kube_public_dns_name: test.domain.com
-      kube_docker_options:
-        data-root: /var/lib/docker
       kube_version: 1.25.3
-      kube_cri_runtime: containerd
-      kube_install_docker_pip: true
+      kube_cri_runtime: crio
       kubelet_extra_args:  '-node-labels=somelabel'

--- a/tests/test-crio.yml
+++ b/tests/test-crio.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  roles:
+    - role: ansible-role-kubernetes
+      kube_install_metrics: true
+      kube_cert_manager: true
+      kube_install_kubeapps: false
+      kube_install_kyverno: false
+      kube_deploy_dashboard: true
+      kube_install_ingress: true
+      kube_public_dns_name: test.domain.com
+      kube_docker_options:
+        data-root: /var/lib/docker
+      kube_version: 1.25.3
+      kube_cri_runtime: containerd
+      kube_install_docker_pip: true
+      kubelet_extra_args:  '-node-labels=somelabel'


### PR DESCRIPTION
Hi there! I've created a pull request to add support for the CRI-O container runtime in our Ansible role for Kubernetes.

This pull request adds a new option for the kube_cri_runtime variable that allows users to specify the container runtime to use. If kube_cri_runtime is set to crio, the role will install and configure CRI-O instead of Docker (that is currently the default option).

I've tested this change by deploying a cluster using the IM client and it seems to be working as expected. However, please review it and let me know if any change is required. 

Thanks!