### PR TITLE
Fix remote_src copy

### DIFF
--- a/tasks/cri-dockerd.yaml
+++ b/tasks/cri-dockerd.yaml
@@ -15,6 +15,7 @@
     src: /tmp/cri-dockerd/cri-dockerd
     dest: /usr/bin/cri-dockerd
     mode: '0755'
+    remote_src: true
 
 - name: Download cri-docker service and socket
   get_url:


### PR DESCRIPTION
By default remote_src is false, so it search for src on the controller node.  Setting remote_src to true it will search for src on the managed node. 